### PR TITLE
Feat:useAuthStore로 로그인 정보 전역관리

### DIFF
--- a/src/api/member.ts
+++ b/src/api/member.ts
@@ -1,0 +1,7 @@
+import { axiosInstance } from "./index";
+
+/* 내 정보 조회 */
+export const fetchMyInfo = async () => {
+    const response = await axiosInstance.get("members/info-all");
+    return response.data;
+};

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import "../css/index.css";
 import localfont from "next/font/local";
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
+import AuthInitializer from "@/components/login/AuthInitializer";
 
 const pretendard = localfont({
     variable: "--font-pretendard",
@@ -24,6 +25,7 @@ export default function RootLayout({
             <body className={`${pretendard.variable}`}>
                 {children}
                 <ToastContainer limit={1} />
+                <AuthInitializer />
             </body>
         </html>
     );

--- a/src/app/login/Login.tsx
+++ b/src/app/login/Login.tsx
@@ -83,11 +83,9 @@ function LoginContent() {
     return (
         <div className="flex h-full w-full flex-col items-center justify-center">
             <div className="mx-5 flex flex-col items-center gap-4">
-                <img
-                    src="/images/logo.png"
-                    alt="logo"
-                    className="mb-10 w-1/2"
-                />
+                <Link href="/" className="mb-10 w-1/2">
+                    <img src="/images/logo.png" alt="logo" />
+                </Link>
 
                 <form
                     className="flex w-full flex-col gap-4"

--- a/src/app/login/Login.tsx
+++ b/src/app/login/Login.tsx
@@ -13,6 +13,7 @@ import {
 import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
 import { useRouter } from "next/navigation";
 import { customAlert } from "@/utils/customAlert";
+import { useAuthStore } from "@/stores/authStore";
 
 const queryClient = new QueryClient();
 
@@ -38,7 +39,7 @@ function LoginContent() {
             const token = response?.data.accessToken;
             console.log(response);
             if (token) {
-                localStorage.setItem("accessToken", token);
+                useAuthStore.getState().login(token);
                 router.push("/");
                 customAlert({
                     message: "로그인 되었습니다!",

--- a/src/app/signup/SignUp.tsx
+++ b/src/app/signup/SignUp.tsx
@@ -37,7 +37,7 @@ function SignUpContent() {
         onSuccess: () => {
             setTimeout(() => {
                 router.push("/signup/success");
-            }, 1500);
+            }, 1000);
         },
         onError: (error) => {
             console.error(error);

--- a/src/app/studylist/page.tsx
+++ b/src/app/studylist/page.tsx
@@ -8,17 +8,20 @@ import SearchBar from "@/components/studyList/SearchBar";
 import Channel from "@/components/studyList/Channel";
 import { useState } from "react";
 import Link from "next/link";
+import { useAuthStore } from "@/stores/authStore";
 
 export default function Page() {
     const [isModalOpen, setIsModalOpen] = useState(false);
     const [selected, setSelected] = useState("전체");
     const [search, setSearch] = useState(""); //검색어
     const [filter, setFilter] = useState<string[]>([]); //지역,활동상태
+    const isLogIn = useAuthStore((state) => state.isLogIn);
 
     const searchHandler = (filters: string[]) => {
         setFilter(filters);
         setIsModalOpen(false);
     };
+
     return (
         <>
             <div className="hide-scrollbar mb-[72px] h-screen min-w-[360px] overflow-y-auto">
@@ -60,11 +63,13 @@ export default function Page() {
                         )}
 
                         {/* 스터디 생성버튼 */}
-                        <Link href="/create">
-                            <div className="fixed right-5 bottom-22 z-30 flex h-[52px] w-[52px] cursor-pointer items-center justify-center rounded-[500px] bg-[var(--color-main400)] shadow-[0_4px_8px_0_rgba(0,0,0,0.32)] transition-all duration-200 ease-in-out hover:bg-[var(--color-main500)]">
-                                <Plus className="h-6 w-6 text-[var(--color-white)]" />
-                            </div>
-                        </Link>
+                        {isLogIn && (
+                            <Link href="/create">
+                                <div className="fixed right-5 bottom-22 z-30 flex h-[52px] w-[52px] cursor-pointer items-center justify-center rounded-[500px] bg-[var(--color-main400)] shadow-[0_4px_8px_0_rgba(0,0,0,0.32)] transition-all duration-200 ease-in-out hover:bg-[var(--color-main500)]">
+                                    <Plus className="h-6 w-6 text-[var(--color-white)]" />
+                                </div>
+                            </Link>
+                        )}
                     </div>
                 </div>
             </div>

--- a/src/components/login/AuthInitializer.tsx
+++ b/src/components/login/AuthInitializer.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { useEffect } from "react";
+import { useAuthStore } from "@/stores/authStore";
+
+export default function AuthInitializer() {
+    useEffect(() => {
+        const token = localStorage.getItem("accessToken");
+        if (!token) return;
+
+        const fetchUser = async () => {
+            await useAuthStore.getState().refetch();
+        };
+
+        fetchUser();
+    }, []);
+
+    console.log(useAuthStore.getState().isLogIn);
+    console.log(useAuthStore.getState().myInfo);
+
+    return null;
+}

--- a/src/components/profile/info/MyInfoList.tsx
+++ b/src/components/profile/info/MyInfoList.tsx
@@ -11,6 +11,7 @@ import {
 } from "@tanstack/react-query";
 import { logout } from "@/api/auth";
 import { customAlert } from "@/utils/customAlert";
+import { useAuthStore } from "@/stores/authStore";
 
 const queryClient = new QueryClient();
 
@@ -28,7 +29,7 @@ function MyInfoListComponent() {
     const { mutate: logoutMutate } = useMutation({
         mutationFn: logout,
         onSuccess() {
-            localStorage.removeItem("accessToken");
+            useAuthStore.getState().logout();
             router.push("/login");
             customAlert({
                 message: "로그아웃 되었습니다!",

--- a/src/components/signup/Step4.tsx
+++ b/src/components/signup/Step4.tsx
@@ -16,12 +16,14 @@ export default function Step4({
     const [isMounted, setIsMounted] = useState(false);
     const [birthday, setBirthday] = useState("");
     const [gender, setGender] = useState("");
+    const [isPreSubmitted, setIsPreSubmitted] = useState(false);
 
     const submitHandler = (e: React.FormEvent<HTMLFormElement>) => {
         e.preventDefault();
 
         if (!birthday || !gender) return;
 
+        setIsPreSubmitted(true);
         requestBirthday(birthday);
         requestGender(gender);
         continueStep();
@@ -75,7 +77,7 @@ export default function Step4({
                     </div>
                 </div>
                 <div className="absolute bottom-5 w-[calc(100%-40px)]">
-                    {birthday && gender ? (
+                    {birthday && gender && !isPreSubmitted ? (
                         <Button type="submit" color="primary">
                             완료하기
                         </Button>

--- a/src/stores/authStore.ts
+++ b/src/stores/authStore.ts
@@ -1,0 +1,28 @@
+import { create } from "zustand";
+import { fetchMyInfo } from "@/api/member";
+
+export const useAuthStore = create<AuthStore>((set) => ({
+    isLogIn: false,
+    myInfo: null,
+    refetch: async () => {
+        const response = await fetchMyInfo();
+        if (response.code === "0000") {
+            set({
+                myInfo: {
+                    ...response.data.memberInfo,
+                    avatarInfo: response.data.avatarInfo,
+                },
+                isLogIn: true,
+            });
+        }
+    },
+    login: (token: string) => {
+        set({ isLogIn: true });
+        localStorage.setItem("accessToken", token);
+        useAuthStore.getState().refetch();
+    },
+    logout: () => {
+        set({ isLogIn: false, myInfo: null });
+        localStorage.removeItem("accessToken");
+    },
+}));

--- a/src/types/auth.d.ts
+++ b/src/types/auth.d.ts
@@ -1,0 +1,25 @@
+interface Avatar {
+    avatarImage: string | null;
+    itemIds: number[];
+}
+
+interface User {
+    id: number;
+    email: string;
+    nickname: string;
+    birthday: string;
+    gender: string;
+    rewardPoints: number;
+    winCount: number;
+    socialType: string;
+    role: string;
+    avatarInfo: Avatar;
+}
+
+interface AuthStore {
+    isLogIn: boolean;
+    myInfo: User | null;
+    refetch: () => Promise<void>;
+    login: (token: string) => void;
+    logout: () => void;
+}


### PR DESCRIPTION
## ✨ PR 개요
- 로그인 정보 전역관리
- 로그인 페이지에서 로고 클릭시 홈으로 이동
- 회원가입 완료 리다이렉트 시간 조정
- 스터디 목록에서 로그인시에만 floatting button 출력

## 🛠️ 작업 상세 내용

이번 PR에서 수행한 작업 유형에 체크해 주세요.

- [x] New Feature (새 기능 추가)
- [ ] Bug Fix (버그 수정)
- [ ] Remove Feature (기능 제거)
- [x] Change Logic (로직 수정)
- [ ] Style (스타일 수정: 코드 포맷, CSS 등)
- [ ] Test (테스트 코드 추가/수정)
- [ ] Set up (환경 설정, 패키지 설정 등)

## 🔥 작업 내용 및 관련 이슈
### 로그인 정보 전역관리
- 로그아웃 로직에 엑세스토큰 제거 대신 `useAuthStore.getstate().logout()` 넣었습니다

#### authStore
- isLogin : 로그인 상태 (boolean)
- myInfo : 로그인 유저 정보 (User | null)
```ts
interface User {
    id: number;
    email: string;
    nickname: string;
    birthday: string;
    gender: string;
    rewardPoints: number;
    winCount: number;
    socialType: string;
    role: string;
    avatarInfo: {
        avatarImage: string | null;
        itemIds: number[];
    }
}
```
- refetch() : 유저 정보 fetch
- login(token: string) : 로그인
    - localStorage에 accessTokern 세팅, user정보 fetch, isLogin true
- logout() : 로그아웃
    - localStorage에 accessTokern 제거, isLogin false

## ✍️ 리뷰 시 참고 사항
### 로그인 상태 가져다 쓰는 법
```tsx
import { useAuthStore } from "@/stores/authStore";

const isLogIn = useAuthStore((state) => state.isLogIn);
```
